### PR TITLE
Add L2Geth compatible build file

### DIFF
--- a/go-ethereum/Dockerfile.build
+++ b/go-ethereum/Dockerfile.build
@@ -1,0 +1,12 @@
+FROM golang:1.14-alpine as builder
+
+RUN apk add --no-cache make gcc musl-dev linux-headers git
+
+ARG BRANCH=master
+
+RUN git clone \
+    --depth=1 \
+    --branch $BRANCH \
+    https://github.com/ethereum-optimism/go-ethereum /go-ethereum \
+    && cd /go-ethereum \
+    && make geth


### PR DESCRIPTION
The build file in the other repository unfortunately does not output an alpine compatible geth binary. This simple build file does!

I remember there was a reason why we wanted to have a single container which handles builds for all of our systems, but it seems that it might end up being harder to maintain vs having a standard `Dockerfile` and `Dockerfile.build` for every environment. We should also probably use the `Dockerfile.build` inside of the `Dockerfile` but I didn't get around to adding it.