### PR TITLE
build: fix tag replacement

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ while (( "$#" )); do
   esac
 done
 
-TAG=$(echo $TAG | sed 's/\//_/')
+TAG=$(echo $TAG | sed 's/\//_/g')
 
 if [ -n "$SERVICE" ]; then
     docker build \


### PR DESCRIPTION
Use the `g` flag with `sed` to globally replace all instances of `/` with `_`. Without `g`, it only replaces the first one.

See https://github.com/ethereum-optimism/optimism-integration/pull/29