### PR TITLE
geth: inject l1 xdomain messenger

### DIFF
--- a/go-ethereum/wait-for-l1.sh
+++ b/go-ethereum/wait-for-l1.sh
@@ -38,6 +38,7 @@ if [ ! -z "$DEPLOYER_HTTP" ]; then
 
     ETH1_ADDRESS_RESOLVER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .AddressManager)
     ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .OVM_L1CrossDomainMessenger)
+    ROLLUP_ADDRESS_MANAGER_OWNER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .Deployer)
     ETH1_NETWORKID=$(curl --silent -H "Content-Type: application/json" \
         --data '{"jsonrpc":"2.0","id":0,"method":"net_version","params":[]}' \
         "$L1_NODE_WEB3_URL" | jq -r .result)
@@ -49,6 +50,7 @@ if [ ! -z "$DEPLOYER_HTTP" ]; then
         ETH1_ADDRESS_RESOLVER_ADDRESS=$ETH1_ADDRESS_RESOLVER_ADDRESS \
         ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS=$ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS \
         ETH1_NETWORKID=$ETH1_NETWORKID \
+        ROLLUP_ADDRESS_MANAGER_OWNER_ADDRESS=$ROLLUP_ADDRESS_MANAGER_OWNER_ADDRESS \
         ETH1_CHAINID=$ETH1_CHAINID \
         $cmd
 else

--- a/go-ethereum/wait-for-l1.sh
+++ b/go-ethereum/wait-for-l1.sh
@@ -37,6 +37,7 @@ if [ ! -z "$DEPLOYER_HTTP" ]; then
     echo "Received address list from $DEPLOYER_HTTP"
 
     ETH1_ADDRESS_RESOLVER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .AddressManager)
+    ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .OVM_L1CrossDomainMessenger)
     ETH1_NETWORKID=$(curl --silent -H "Content-Type: application/json" \
         --data '{"jsonrpc":"2.0","id":0,"method":"net_version","params":[]}' \
         "$L1_NODE_WEB3_URL" | jq -r .result)
@@ -46,6 +47,7 @@ if [ ! -z "$DEPLOYER_HTTP" ]; then
 
     exec env \
         ETH1_ADDRESS_RESOLVER_ADDRESS=$ETH1_ADDRESS_RESOLVER_ADDRESS \
+        ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS=$ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS \
         ETH1_NETWORKID=$ETH1_NETWORKID \
         ETH1_CHAINID=$ETH1_CHAINID \
         $cmd


### PR DESCRIPTION
Injects the cross domain messenger into the geth runtime when the `DEPLOYER_HTTP` is set

Corresponding PR: https://github.com/ethereum-optimism/go-ethereum/pull/109
Need to check that the environment variable is the same in both