### PR TITLE
batch-submitter: push timeout ahead

### DIFF
--- a/batch-submitter/wait-for-l1-and-l2.sh
+++ b/batch-submitter/wait-for-l1-and-l2.sh
@@ -38,7 +38,7 @@ if [ ! -z "$DEPLOYER_HTTP" ]; then
     echo "Contracts are deployed"
 fi
 
-RETRIES=20
+RETRIES=30
 until $(curl --silent --fail \
     --output /dev/null \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
Updates the timeout so that running the verifier along with this doesn't result in a timeout