### PR TITLE
Add L1 Messenger address to env

### DIFF
--- a/integration-tests/wait-for-l1-and-l2-and-contract-deployment.sh
+++ b/integration-tests/wait-for-l1-and-l2-and-contract-deployment.sh
@@ -53,7 +53,9 @@ echo "Connected to L2 Node at $L2_NODE_WEB3_URL"
 
 
 ETH1_ADDRESS_RESOLVER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .AddressManager)
+L1_MESSENGER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .Proxy__OVM_L1CrossDomainMessenger)
 
 exec env \
     ETH1_ADDRESS_RESOLVER_ADDRESS=$ETH1_ADDRESS_RESOLVER_ADDRESS \
+    L1_MESSENGER_ADDRESS=$L1_MESSENGER_ADDRESS \
     $cmd


### PR DESCRIPTION
This new env var is required for the L1<->L2 tests in the integration-tests repo. See https://github.com/ethereum-optimism/integration-tests/pull/31/commits/e6879f43b0c622bd4077b7ac4507535801de2e4a