### PR TITLE
fraud-prover: add `NO_TIMEOUT` config option

### DIFF
--- a/fraud-prover/wait-for-l1-and-l2.sh
+++ b/fraud-prover/wait-for-l1-and-l2.sh
@@ -13,14 +13,11 @@ until $(curl --silent --fail \
     -H "Content-Type: application/json" \
     --data "$JSON" "$L1_NODE_WEB3_URL"); do
   sleep 1
+  echo "Will wait $((RETRIES--)) more times for $L1_NODE_WEB3_URL to be up..."
 
-  if [ ! -z "$NO_TIMEOUT" ]; then
-      echo "Waiting for $L2_NODE_WEB3_URL to be up..."
-  elif [ "$RETRIES" -lt 0 ]; then
-    echo "Timeout waiting for layer two node at $L2_NODE_WEB3_URL"
+  if [ "$RETRIES" -lt 0 ]; then
+    echo "Timeout waiting for layer two node at $L1_NODE_WEB3_URL"
     exit 1
-  else
-    echo "Will wait $((RETRIES--)) more times for $L2_NODE_WEB3_URL to be up..."
   fi
 done
 echo "Connected to L1 Node at $L1_NODE_WEB3_URL"
@@ -31,11 +28,13 @@ until $(curl --silent --fail \
     -H "Content-Type: application/json" \
     --data "$JSON" "$L2_NODE_WEB3_URL"); do
   sleep 1
-  echo "Will wait $((RETRIES--)) more times for $L2_NODE_WEB3_URL to be up..."
-
-  if [ "$RETRIES" -lt 0 ]; then
+  if [ ! -z "$NO_TIMEOUT" ]; then
+      echo "Waiting for $L2_NODE_WEB3_URL to be up..."
+  elif [ "$RETRIES" -lt 0 ]; then
     echo "Timeout waiting for layer two node at $L2_NODE_WEB3_URL"
     exit 1
+  else
+    echo "Will wait $((RETRIES--)) more times for $L2_NODE_WEB3_URL to be up..."
   fi
 done
 echo "Connected to L2 Node at $L2_NODE_WEB3_URL"

--- a/fraud-prover/wait-for-l1-and-l2.sh
+++ b/fraud-prover/wait-for-l1-and-l2.sh
@@ -30,6 +30,7 @@ until $(curl --silent --fail \
   sleep 1
   if [ ! -z "$NO_TIMEOUT" ]; then
       echo "Waiting for $L2_NODE_WEB3_URL to be up..."
+      sleep 60
   elif [ "$RETRIES" -lt 0 ]; then
     echo "Timeout waiting for layer two node at $L2_NODE_WEB3_URL"
     exit 1

--- a/fraud-prover/wait-for-l1-and-l2.sh
+++ b/fraud-prover/wait-for-l1-and-l2.sh
@@ -16,7 +16,7 @@ until $(curl --silent --fail \
   echo "Will wait $((RETRIES--)) more times for $L1_NODE_WEB3_URL to be up..."
 
   if [ "$RETRIES" -lt 0 ]; then
-    echo "Timeout waiting for layer two node at $L1_NODE_WEB3_URL"
+    echo "Timeout waiting for layer one node at $L1_NODE_WEB3_URL"
     exit 1
   fi
 done

--- a/fraud-prover/wait-for-l1-and-l2.sh
+++ b/fraud-prover/wait-for-l1-and-l2.sh
@@ -30,7 +30,7 @@ until $(curl --silent --fail \
   sleep 1
   if [ ! -z "$NO_TIMEOUT" ]; then
       echo "Waiting for $L2_NODE_WEB3_URL to be up..."
-      sleep 60
+      sleep 30
   elif [ "$RETRIES" -lt 0 ]; then
     echo "Timeout waiting for layer two node at $L2_NODE_WEB3_URL"
     exit 1

--- a/fraud-prover/wait-for-l1-and-l2.sh
+++ b/fraud-prover/wait-for-l1-and-l2.sh
@@ -13,11 +13,14 @@ until $(curl --silent --fail \
     -H "Content-Type: application/json" \
     --data "$JSON" "$L1_NODE_WEB3_URL"); do
   sleep 1
-  echo "Will wait $((RETRIES--)) more times for $L1_NODE_WEB3_URL to be up..."
 
-  if [ "$RETRIES" -lt 0 ]; then
-    echo "Timeout waiting for layer one node at $L1_NODE_WEB3_URL"
+  if [ ! -z "$NO_TIMEOUT" ]; then
+      echo "Waiting for $L2_NODE_WEB3_URL to be up..."
+  elif [ "$RETRIES" -lt 0 ]; then
+    echo "Timeout waiting for layer two node at $L2_NODE_WEB3_URL"
     exit 1
+  else
+    echo "Will wait $((RETRIES--)) more times for $L2_NODE_WEB3_URL to be up..."
   fi
 done
 echo "Connected to L1 Node at $L1_NODE_WEB3_URL"


### PR DESCRIPTION
Adds the `NO_TIMEOUT` config option to the entrypoint, which will result in the entrypoint never timing out. This is useful because L2 doesn't have its RPC on while its syncing