### PR TITLE
Update address manager env var naming for consistency

### DIFF
--- a/go-ethereum/wait-for-l1.sh
+++ b/go-ethereum/wait-for-l1.sh
@@ -36,7 +36,7 @@ if [ ! -z "$DEPLOYER_HTTP" ]; then
     done
     echo "Received address list from $DEPLOYER_HTTP"
 
-    ETH1_ADDRESS_RESOLVER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .AddressManager)
+    ETH1_ADDRESS_MANAGER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .AddressManager)
     ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS=$(curl --silent \
         $DEPLOYER_HTTP/addresses.json | jq -r .Proxy__OVM_L1CrossDomainMessenger)
     ROLLUP_ADDRESS_MANAGER_OWNER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .Deployer)
@@ -48,7 +48,7 @@ if [ ! -z "$DEPLOYER_HTTP" ]; then
         "$L1_NODE_WEB3_URL" | jq -r .result | xargs printf '%d')
 
     exec env \
-        ETH1_ADDRESS_RESOLVER_ADDRESS=$ETH1_ADDRESS_RESOLVER_ADDRESS \
+        ETH1_ADDRESS_MANAGER_ADDRESS=$ETH1_ADDRESS_MANAGER_ADDRESS \
         ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS=$ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS \
         ETH1_NETWORKID=$ETH1_NETWORKID \
         ROLLUP_ADDRESS_MANAGER_OWNER_ADDRESS=$ROLLUP_ADDRESS_MANAGER_OWNER_ADDRESS \

--- a/integration-tests/wait-for-l1-and-l2-and-contract-deployment.sh
+++ b/integration-tests/wait-for-l1-and-l2-and-contract-deployment.sh
@@ -52,8 +52,8 @@ done
 echo "Connected to L2 Node at $L2_NODE_WEB3_URL"
 
 
-ETH1_ADDRESS_RESOLVER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .AddressManager)
+ETH1_ADDRESS_MANAGER_ADDRESS=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .AddressManager)
 
 exec env \
-    ETH1_ADDRESS_RESOLVER_ADDRESS=$ETH1_ADDRESS_RESOLVER_ADDRESS \
+    ETH1_ADDRESS_MANAGER_ADDRESS=$ETH1_ADDRESS_MANAGER_ADDRESS \
     $cmd


### PR DESCRIPTION
The Address manager has different names in different places i.e. ETH1_ADDRESS_RESOLVER_ADDRESS vs AddressManager. We should make this less confusing by making the names consistent.