### PR TITLE
batch-submitter: update dockerfile for new repo

### DIFF
--- a/batch-submitter/Dockerfile
+++ b/batch-submitter/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update \
 
 ARG BRANCH=master
 
-RUN git clone https://github.com/ethereum-optimism/optimism-monorepo /opt/optimism-monorepo \
-    && cd /opt/optimism-monorepo \
+RUN git clone https://github.com/ethereum-optimism/batch-submitter /opt/batch-submitter \
+    && cd /opt/batch-submitter \
     && git checkout $BRANCH \
     && yarn install \
     && yarn build
@@ -16,9 +16,9 @@ FROM node:10.23-buster
 RUN apt-get update \
     && apt-get install -y bash curl
 
-COPY --from=build /opt/optimism-monorepo /opt/optimism-monorepo
+COPY --from=build /opt/batch-submitter /opt/batch-submitter
 COPY wait-for-l1-and-l2.sh /opt/
-RUN ln -s /opt/optimism-monorepo/packages/batch-submitter/exec/run-batch-submitter.js \
+RUN ln -s /opt/batch-submitter/exec/run-batch-submitter.js \
     /usr/local/bin/
 
 ENTRYPOINT ["/opt/wait-for-l1-and-l2.sh", "run-batch-submitter.js"]


### PR DESCRIPTION
Updates `batch-submitter/Dockerfile` to use the new repo https://github.com/ethereum-optimism/batch-submitter