### PR TITLE
deployer: verify etherscan updates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,7 @@ ORG=ethereumoptimism
 SERVICE=""
 GIT_BRANCH=master
 TAG=$GIT_BRANCH
+REMOTE=""
 
 while (( "$#" )); do
   case "$1" in
@@ -29,6 +30,15 @@ while (( "$#" )); do
       if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
         GIT_BRANCH="$2"
         TAG=$GIT_BRANCH
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -r|--remote)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        REMOTE="$2"
         shift 2
       else
         echo "Error: Argument for $1 is missing" >&2
@@ -80,6 +90,7 @@ if [ -n "$SERVICE" ]; then
         --label "io.optimism.repo=docker" \
         --label "io.optimism.repo.git.branch=$GIT_BRANCH" \
         --build-arg BRANCH=$GIT_BRANCH \
+        --build-arg REMOTE=$REMOTE \
         -f $DIR/$SERVICE/Dockerfile \
         -t $ORG/$SERVICE:$TAG $DIR/$SERVICE
 

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -4,8 +4,9 @@ RUN apt-get update \
     && apt-get install -y bash git python build-essential libusb-1.0
 
 ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/contracts-v2
 
-RUN git clone https://github.com/ethereum-optimism/contracts-v2 /opt/contracts-v2 \
+RUN git clone $REMOTE /opt/contracts-v2 \
     && cd /opt/contracts-v2 \
     && git checkout $BRANCH \
     && yarn install \


### PR DESCRIPTION
Adds a verify etherscan hook into the docker entrypoint. It may be more ideal to decouple this from needing to run inside of the container, but we could make it best practice to do deploys from within containers for security reasons