### PR TITLE
feature: add remote flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,17 @@ Repo for building, tagging and pushing Docker images
 ### `build.sh`
 
 Build Docker images, use the `-s` flag to select a service to build.
-If no `-s` flag is passed, all images will be built.
+If no `-s` flag is passed, all images will be built. Each service that
+can be built is represented by a directory in this repository.
 
 ### `clean.sh`
 
 Remove Docker images related to this repo from the machine.
+
+## Developing
+
+Add a directory to this repository that contains a `Dockerfile` and
+any files that are necessary to build the docker image. This repository
+is opinionated when it comes to building docker images in a position
+independent way, meaning that the `Dockerfile`s all build by cloning
+the code from a remote git repository.

--- a/batch-submitter/Dockerfile
+++ b/batch-submitter/Dockerfile
@@ -1,10 +1,14 @@
+ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/batch-submitter
+
 FROM node:10.23-buster as build
 
 RUN apt-get update \
     && apt-get install -y bash git python build-essential
 
-ARG BRANCH=master
-ARG REMOTE=https://github.com/ethereum-optimism/batch-submitter
+ARG BRANCH
+ARG REMOTE
+LABEL io.optimism.repo.git.remote=$REMOTE
 
 RUN git clone $REMOTE /opt/batch-submitter \
     && cd /opt/batch-submitter \
@@ -13,6 +17,8 @@ RUN git clone $REMOTE /opt/batch-submitter \
     && yarn build
 
 FROM node:10.23-buster
+ARG REMOTE
+LABEL io.optimism.repo.git.remote=$REMOTE
 
 RUN apt-get update \
     && apt-get install -y bash curl

--- a/batch-submitter/Dockerfile
+++ b/batch-submitter/Dockerfile
@@ -4,8 +4,9 @@ RUN apt-get update \
     && apt-get install -y bash git python build-essential
 
 ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/batch-submitter
 
-RUN git clone https://github.com/ethereum-optimism/batch-submitter /opt/batch-submitter \
+RUN git clone $REMOTE /opt/batch-submitter \
     && cd /opt/batch-submitter \
     && git checkout $BRANCH \
     && yarn install \

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -1,11 +1,12 @@
-FROM node:10.23-buster as build
+ARG REMOTE=https://github.com/ethereum-optimism/contracts-v2
+ARG BRANCH=master
 
+FROM node:10.23-buster as build
 RUN apt-get update \
     && apt-get install -y bash git python build-essential libusb-1.0
 
-ARG BRANCH=master
-ARG REMOTE=https://github.com/ethereum-optimism/contracts-v2
-
+ARG REMOTE
+ARG BRANCH
 RUN git clone $REMOTE /opt/contracts-v2 \
     && cd /opt/contracts-v2 \
     && git checkout $BRANCH \
@@ -13,6 +14,9 @@ RUN git clone $REMOTE /opt/contracts-v2 \
     && yarn build
 
 FROM node:10.23-buster
+ARG REMOTE
+LABEL io.optimism.repo.git.remote=$REMOTE
+
 RUN apt-get update \
     && apt-get install -y bash curl jq python3 libusb-1.0 \
     && mv /usr/bin/python /usr/bin/python2 \

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -4,8 +4,9 @@ RUN apt-get update \
     && apt-get install -y bash git python build-essential libusb-1.0
 
 ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/contracts-v2
 
-RUN git clone https://github.com/ethereum-optimism/contracts-v2 /opt/contracts-v2 \
+RUN git clone $REMOTE /opt/contracts-v2 \
     && cd /opt/contracts-v2 \
     && git checkout $BRANCH \
     && yarn install \

--- a/fraud-prover/Dockerfile
+++ b/fraud-prover/Dockerfile
@@ -1,3 +1,6 @@
+ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/optimism-ts-services
+
 FROM node:10.23-buster as base
 
 RUN apt-get update \
@@ -8,8 +11,8 @@ FROM base as build
 RUN apt-get update \
     && apt-get install -y git python build-essential
 
-ARG BRANCH=master
-ARG REMOTE=https://github.com/ethereum-optimism/optimism-ts-services
+ARG BRANCH
+ARG REMOTE
 
 RUN git clone $REMOTE /opt/optimism-ts-services \
     && cd /opt/optimism-ts-services \
@@ -18,6 +21,8 @@ RUN git clone $REMOTE /opt/optimism-ts-services \
     && yarn build
 
 FROM base
+ARG REMOTE
+LABEL io.optimism.repo.git.remote=$REMOTE
 
 COPY --from=build /opt/optimism-ts-services /opt/optimism-ts-services
 COPY wait-for-l1-and-l2.sh /opt/

--- a/fraud-prover/Dockerfile
+++ b/fraud-prover/Dockerfile
@@ -9,8 +9,9 @@ RUN apt-get update \
     && apt-get install -y git python build-essential
 
 ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/optimism-ts-services
 
-RUN git clone https://github.com/ethereum-optimism/optimism-ts-services /opt/optimism-ts-services \
+RUN git clone $REMOTE /opt/optimism-ts-services \
     && cd /opt/optimism-ts-services \
     && git checkout $BRANCH \
     && yarn install \

--- a/go-ethereum/Dockerfile
+++ b/go-ethereum/Dockerfile
@@ -1,10 +1,13 @@
+ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/go-ethereum
+
 FROM golang:1.14-buster as builder
 
 RUN apt-get update \
   && apt-get install -y build-essential
 
-ARG BRANCH=master
-ARG REMOTE=https://github.com/ethereum-optimism/go-ethereum
+ARG BRANCH
+ARG REMOTE
 
 RUN git clone \
     --depth=1 \
@@ -14,6 +17,10 @@ RUN git clone \
     && make geth
 
 FROM golang:1.14-buster
+
+ARG BRANCH
+ARG REMOTE
+LABEL io.optimism.repo.git.remote=$REMOTE
 
 RUN apt-get update \
     && apt-get install -y bash curl jq ca-certificates

--- a/go-ethereum/Dockerfile
+++ b/go-ethereum/Dockerfile
@@ -4,11 +4,12 @@ RUN apt-get update \
   && apt-get install -y build-essential
 
 ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/go-ethereum
 
 RUN git clone \
     --depth=1 \
     --branch $BRANCH \
-    https://github.com/ethereum-optimism/go-ethereum /go-ethereum \
+    $REMOTE /go-ethereum \
     && cd /go-ethereum \
     && make geth
 

--- a/hardhat/Dockerfile
+++ b/hardhat/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:10.23-buster as build
+FROM node:10.23-buster
 
 RUN apt-get update \
     && apt-get install -y bash git python build-essential
 
 ARG BRANCH=master
 ARG REMOTE=https://github.com/ethereum-optimism/hardhat
+LABEL io.optimism.repo.git.remote=$REMOTE
 
 RUN git clone $REMOTE /opt/hardhat \
     && cd /opt/hardhat \

--- a/hardhat/Dockerfile
+++ b/hardhat/Dockerfile
@@ -4,8 +4,9 @@ RUN apt-get update \
     && apt-get install -y bash git python build-essential
 
 ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/hardhat
 
-RUN git clone https://github.com/ethereum-optimism/hardhat.git /opt/hardhat \
+RUN git clone $REMOTE /opt/hardhat \
     && cd /opt/hardhat \
     && git checkout $BRANCH \
     && yarn

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:10.23-buster as build
+FROM node:10.23-buster
 
 RUN apt-get update \
     && apt-get install -y bash git python build-essential jq
 
 ARG BRANCH=master
 ARG REMOTE=https://github.com/ethereum-optimism/integration-tests
+LABEL io.optimism.repo.git.remote=$REMOTE
 
 RUN git clone \
     --depth=1 \

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -4,11 +4,12 @@ RUN apt-get update \
     && apt-get install -y bash git python build-essential jq
 
 ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/integration-tests
 
 RUN git clone \
     --depth=1 \
     --branch $BRANCH \
-    https://github.com/ethereum-optimism/integration-tests /integration-tests \
+    $REMOTE /integration-tests \
     && cd /integration-tests \
     && yarn install \
     && yarn build

--- a/integration-tests/wait-for-l1-and-l2-and-contract-deployment.sh
+++ b/integration-tests/wait-for-l1-and-l2-and-contract-deployment.sh
@@ -23,18 +23,20 @@ done
 echo "Connected to L1 Node at $L1_NODE_WEB3_URL"
 
 RETRIES=20
-until $(curl --silent --fail \
-    --output /dev/null \
-    "$DEPLOYER_HTTP/addresses.json"); do
-  sleep 1
-  echo "Will wait $((RETRIES--)) more times for $DEPLOYER_HTTP to be up..."
+if [ ! -z "$DEPLOYER_HTTP" ]; then
+    until $(curl --silent --fail \
+        --output /dev/null \
+        "$DEPLOYER_HTTP/addresses.json"); do
+      sleep 1
+      echo "Will wait $((RETRIES--)) more times for $DEPLOYER_HTTP to be up..."
 
-  if [ "$RETRIES" -lt 0 ]; then
-    echo "Timeout waiting for contract deployment"
-    exit 1
-  fi
-done
-echo "Contracts are deployed"
+      if [ "$RETRIES" -lt 0 ]; then
+        echo "Timeout waiting for contract deployment"
+        exit 1
+      fi
+    done
+    echo "Contracts are deployed"
+fi
 
 RETRIES=30
 until $(curl --silent --fail \

--- a/message-relayer/Dockerfile
+++ b/message-relayer/Dockerfile
@@ -9,8 +9,9 @@ RUN apt-get update \
     && apt-get install -y bash git python build-essential
 
 ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/optimism-ts-services
 
-RUN git clone https://github.com/ethereum-optimism/optimism-ts-services /opt/optimism-ts-services \
+RUN git clone $REMOTE /opt/optimism-ts-services \
     && cd /opt/optimism-ts-services \
     && git checkout $BRANCH \
     && yarn install \

--- a/message-relayer/Dockerfile
+++ b/message-relayer/Dockerfile
@@ -1,3 +1,6 @@
+ARG BRANCH=master
+ARG REMOTE=https://github.com/ethereum-optimism/optimism-ts-services
+
 FROM node:10.23-buster as base
 
 RUN apt-get update \
@@ -8,8 +11,8 @@ FROM base as build
 RUN apt-get update \
     && apt-get install -y bash git python build-essential
 
-ARG BRANCH=master
-ARG REMOTE=https://github.com/ethereum-optimism/optimism-ts-services
+ARG BRANCH
+ARG REMOTE
 
 RUN git clone $REMOTE /opt/optimism-ts-services \
     && cd /opt/optimism-ts-services \
@@ -18,6 +21,8 @@ RUN git clone $REMOTE /opt/optimism-ts-services \
     && yarn build
 
 FROM base
+ARG REMOTE
+LABEL io.optimism.repo.git.remote=$REMOTE
 
 RUN apt-get update \
     && apt-get install -y bash curl jq


### PR DESCRIPTION
This PR adds a `-r`/`--remote` flag to the docker build script so that it can be used to build images based on forks of the codebase. This will enable outside contributions to run against CI by passing in the remote as an argument