### PR TITLE
config: update dtl entrypoint

### DIFF
--- a/data-transport-layer/wait-for-l1.sh
+++ b/data-transport-layer/wait-for-l1.sh
@@ -10,7 +10,7 @@ L1_NODE_WEB3_URL=$DATA_TRANSPORT_LAYER__L1_RPC_ENDPOINT
 L2_NODE_WEB3_URL=$DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT
 DATA_TRANSPORT_LAYER__L2_CHAIN_ID=$DATA_TRANSPORT_LAYER__L2_CHAIN_ID
 
-RETRIES=20
+RETRIES=${RETRIES:-20}
 until $(curl --silent --fail \
     --output /dev/null \
     -H "Content-Type: application/json" \
@@ -26,7 +26,7 @@ done
 echo "Connected to L1 Node at $L1_NODE_WEB3_URL"
 
 if [[ "$DATA_TRANSPORT_LAYER__SYNC_FROM_L2" == true ]]; then
-    RETRIES=20
+    RETRIES=${RETRIES:-20}
     until $(curl --silent --fail \
         --output /dev/null \
         -H "Content-Type: application/json" \
@@ -48,7 +48,7 @@ if [[ "$DATA_TRANSPORT_LAYER__SYNC_FROM_L2" == true ]]; then
 fi
 
 if [ ! -z "$DEPLOYER_HTTP" ]; then
-    RETRIES=20
+    RETRIES=${RETRIES:-20}
     until $(curl --silent --fail \
         --output /dev/null \
         "$DEPLOYER_HTTP/addresses.json"); do

--- a/data-transport-layer/wait-for-l1.sh
+++ b/data-transport-layer/wait-for-l1.sh
@@ -44,7 +44,7 @@ if [[ "$DATA_TRANSPORT_LAYER__SYNC_FROM_L2" == true ]]; then
     DATA_TRANSPORT_LAYER__L2_CHAIN_ID=$(curl --silent -H \
         "Content-Type: application/json" \
         --data '{"jsonrpc":"2.0","id":0,"method":"eth_chainId","params":[]}' \
-        "$L2_NODE_WEB3_URL")
+        "$L2_NODE_WEB3_URL" | jq -r .result)
 fi
 
 if [ ! -z "$DEPLOYER_HTTP" ]; then

--- a/data-transport-layer/wait-for-l1.sh
+++ b/data-transport-layer/wait-for-l1.sh
@@ -5,8 +5,10 @@
 # github.com/ethereum-optimism
 
 cmd="$@"
-JSON='{"jsonrpc":"2.0","id":0,"method":"net_version","params":[]}'
+JSON='{"jsonrpc":"2.0","id":0,"method":"eth_chainId","params":[]}'
 L1_NODE_WEB3_URL=$DATA_TRANSPORT_LAYER__L1_RPC_ENDPOINT
+L2_NODE_WEB3_URL=$DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT
+DATA_TRANSPORT_LAYER__L2_CHAIN_ID=$DATA_TRANSPORT_LAYER__L2_CHAIN_ID
 
 RETRIES=20
 until $(curl --silent --fail \
@@ -22,6 +24,28 @@ until $(curl --silent --fail \
   fi
 done
 echo "Connected to L1 Node at $L1_NODE_WEB3_URL"
+
+if [[ "$DATA_TRANSPORT_LAYER__SYNC_FROM_L2" == true ]]; then
+    RETRIES=20
+    until $(curl --silent --fail \
+        --output /dev/null \
+        -H "Content-Type: application/json" \
+        --data "$JSON" "$L2_NODE_WEB3_URL"); do
+      sleep 1
+      echo "Will wait $((RETRIES--)) more times for $L2_NODE_WEB3_URL to be up..."
+
+      if [ "$RETRIES" -lt 0 ]; then
+        echo "Timeout waiting for layer one node at $L2_NODE_WEB3_URL"
+        exit 1
+      fi
+    done
+    echo "Connected to L2 Node at $L2_NODE_WEB3_URL"
+
+    DATA_TRANSPORT_LAYER__L2_CHAIN_ID=$(curl --silent -H \
+        "Content-Type: application/json" \
+        --data '{"jsonrpc":"2.0","id":0,"method":"eth_chainId","params":[]}' \
+        "$L2_NODE_WEB3_URL")
+fi
 
 if [ ! -z "$DEPLOYER_HTTP" ]; then
     RETRIES=20
@@ -41,6 +65,7 @@ if [ ! -z "$DEPLOYER_HTTP" ]; then
     DATA_TRANSPORT_LAYER__ADDRESS_MANAGER=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .AddressManager)
     exec env \
         DATA_TRANSPORT_LAYER__ADDRESS_MANAGER=$DATA_TRANSPORT_LAYER__ADDRESS_MANAGER \
+        DATA_TRANSPORT_LAYER__L2_CHAIN_ID=$DATA_TRANSPORT_LAYER__L2_CHAIN_ID \
         $cmd
 else
     exec $cmd


### PR DESCRIPTION
This PR enables for automation around the new data transport sync mode. Optionally wait for the remote layer two node to become available because there is a dependency on the remote node being ready before the dtl starts. Also pull in the remote node's chainid to inject at runtime.