### PR TITLE
Fix deployer up.sh -l

### DIFF
--- a/deployer/wait-for-l1.sh
+++ b/deployer/wait-for-l1.sh
@@ -24,10 +24,10 @@ done
 echo "Connected to L1 Node at $L1_NODE_WEB3_URL"
 
 RESULT=$(exec $cmd)
-echo "$RESULT" | tee /opt/contracts/build/addresses.json
+echo "$RESULT" | tee /contracts/build/addresses.json
 
 echo "Starting HTTP server on $SERVER_PORT"
 python \
     -m http.server \
     --bind 0.0.0.0 $SERVER_PORT \
-    --directory /opt/contracts/build
+    --directory /contracts/build


### PR DESCRIPTION
My `up.sh -l` was not updating when I built locally -- looks like it was serving from the wrong build location.