### PR TITLE
ci: build failover prxy

### DIFF
--- a/.github/workflows/dockerhub-build-push.yml
+++ b/.github/workflows/dockerhub-build-push.yml
@@ -20,15 +20,20 @@ jobs:
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }} | docker login -u ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME}} --password-stdin
 
-      - name: Build and push Build image to DockerHub
+      - name: Build and push Builder image to DockerHub
         run: |
-          git clone https://github.com/ethereum-optimism/docker.git \
-              $HOME/docker
-          cd $HOME/docker
           BRANCH=${GITHUB_REF##*/}
           ./build.sh -s builder -b $BRANCH
           if [ $BRANCH == 'master' ]; then
               docker push ethereumoptimism/builder:latest
+          fi
+
+      - name: Build and push Failover proxy image to DockerHub
+        run: |
+          BRANCH=${GITHUB_REF##*/}
+          ./build.sh -s failover-proxy -b $BRANCH
+          if [ $BRANCH == 'master' ]; then
+              docker push ethereumoptimism/failover-proxy:latest
           fi
 
       - name: Logout of DockerHub


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds CI automation around the failover proxy. This proxy can fallback to other eth1 providers if the request fails

**Additional context**
This is useful for the devops overhaul

**Metadata**
- Fixes #[Link to Issue]
