### PR TITLE
failover-proxy: configurable port

### DIFF
--- a/failover-proxy/Dockerfile
+++ b/failover-proxy/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:stable
 
 ARG VERSION=v3.9.0
+ENV HTTP_PORT=8000
 
 RUN curl -o /usr/local/bin/gomplate \
     -sSL https://github.com/hairyhenderson/gomplate/releases/download/$VERSION/gomplate_linux-amd64-slim \

--- a/failover-proxy/README.md
+++ b/failover-proxy/README.md
@@ -6,9 +6,6 @@ depends on a single environment variable `SERVICES` which is a comma
 separated string of URLs. The first item is the main backend to be queried
 and any subsequent backends will be used as fallbacks.
 
-It is currently configured to listen on port `8545` because it is being used
-to provide redundency for Ethereum providers.
-
 To build the failover proxy, use the command:
 
 ```bash
@@ -18,7 +15,8 @@ $ ./build.sh -s failover-proxy
 To run:
 
 ```bash
-$ docker run --rm -p 8545:8545 \
+$ docker run --rm -p 8000:8000 \
     -e "SERVICES=http://my-eth-1-provider,http://my-backup" \
+    -e "HTTP_PORT=8000" \
     ethereumoptimism/failover-proxy:latest
 ```

--- a/failover-proxy/nginx.template.conf
+++ b/failover-proxy/nginx.template.conf
@@ -43,7 +43,7 @@ http {
     {{end}}
 
     server {
-        listen 0.0.0.0:8545;
+        listen 0.0.0.0:{{ env.Getenv "HTTP_PORT" }};
         location / {
             proxy_pass http://rpc;
         }


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the `failover-proxy` to include the ability to set the port it listens on

**Additional context**
Helpful for nice devops

**Metadata**
- Fixes #[Link to Issue]
