### PR TITLE
refactor: Rename data-transport-layer to transaction-indexer

### DIFF
--- a/data-transport-layer/Dockerfile
+++ b/data-transport-layer/Dockerfile
@@ -10,8 +10,8 @@ RUN git ls-remote $REMOTE | grep heads/$BRANCH | tee /cache.txt
 RUN git clone \
     --depth=1 \
     --branch $BRANCH \
-    $REMOTE /opt/data-transport-layer \
-    && cd /opt/data-transport-layer \
+    $REMOTE /opt/transaction-indexer \
+    && cd /opt/transaction-indexer \
     && yarn install \
     && yarn build
 
@@ -19,9 +19,9 @@ FROM node:14-buster
 RUN apt-get update \
     && apt-get install -y bash curl jq
 
-COPY --from=build /opt/data-transport-layer /opt/data-transport-layer
+COPY --from=build /opt/transaction-indexer /opt/transaction-indexer
 COPY wait-for-l1.sh /opt/wait-for-l1.sh
 
-WORKDIR /opt/data-transport-layer
+WORKDIR /opt/transaction-indexer
 
 ENTRYPOINT ["/opt/wait-for-l1.sh", "yarn", "start"]

--- a/data-transport-layer/wait-for-l1.sh
+++ b/data-transport-layer/wait-for-l1.sh
@@ -6,13 +6,13 @@
 
 cmd="$@"
 JSON='{"jsonrpc":"2.0","id":0,"method":"eth_chainId","params":[]}'
-L1_NODE_WEB3_URL=$DATA_TRANSPORT_LAYER__L1_RPC_ENDPOINT
-L2_NODE_WEB3_URL=$DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT
-DATA_TRANSPORT_LAYER__L2_CHAIN_ID=$DATA_TRANSPORT_LAYER__L2_CHAIN_ID
+L1_NODE_WEB3_URL=$TRANSACTION_INDEXER__L1_RPC_ENDPOINT
+L2_NODE_WEB3_URL=$TRANSACTION_INDEXER__L2_RPC_ENDPOINT
+TRANSACTION_INDEXER__L2_CHAIN_ID=$TRANSACTION_INDEXER__L2_CHAIN_ID
 
-if [[ "$DATA_TRANSPORT_LAYER__SYNC_FROM_L1" == true ]]; then
+if [[ "$TRANSACTION_INDEXER__SYNC_FROM_L1" == true ]]; then
     if [[ -z "$L1_NODE_WEB3_URL" ]]; then
-        echo "Missing DATA_TRANSPORT_LAYER__L1_RPC_ENDPOINT env var"
+        echo "Missing TRANSACTION_INDEXER__L1_RPC_ENDPOINT env var"
         exit 1
     fi
 fi
@@ -32,9 +32,9 @@ until $(curl --silent --fail \
 done
 echo "Connected to L1 Node at $L1_NODE_WEB3_URL"
 
-if [[ "$DATA_TRANSPORT_LAYER__SYNC_FROM_L2" == true ]]; then
+if [[ "$TRANSACTION_INDEXER__SYNC_FROM_L2" == true ]]; then
     if [[ -z "$L2_NODE_WEB3_URL" ]]; then
-        echo "Missing DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT env var"
+        echo "Missing TRANSACTION_INDEXER__L2_RPC_ENDPOINT env var"
         exit 1
     fi
 
@@ -53,7 +53,7 @@ if [[ "$DATA_TRANSPORT_LAYER__SYNC_FROM_L2" == true ]]; then
     done
     echo "Connected to L2 Node at $L2_NODE_WEB3_URL"
 
-    DATA_TRANSPORT_LAYER__L2_CHAIN_ID=$(curl --silent -H \
+    TRANSACTION_INDEXER__L2_CHAIN_ID=$(curl --silent -H \
         "Content-Type: application/json" \
         --data '{"jsonrpc":"2.0","id":0,"method":"eth_chainId","params":[]}' \
         "$L2_NODE_WEB3_URL" | jq -r .result | xargs printf '%d')
@@ -74,10 +74,10 @@ if [ ! -z "$DEPLOYER_HTTP" ]; then
     done
     echo "Received address list from $DEPLOYER_HTTP"
 
-    DATA_TRANSPORT_LAYER__ADDRESS_MANAGER=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .AddressManager)
+    TRANSACTION_INDEXER__ADDRESS_MANAGER=$(curl --silent $DEPLOYER_HTTP/addresses.json | jq -r .AddressManager)
     exec env \
-        DATA_TRANSPORT_LAYER__ADDRESS_MANAGER=$DATA_TRANSPORT_LAYER__ADDRESS_MANAGER \
-        DATA_TRANSPORT_LAYER__L2_CHAIN_ID=$DATA_TRANSPORT_LAYER__L2_CHAIN_ID \
+        TRANSACTION_INDEXER__ADDRESS_MANAGER=$TRANSACTION_INDEXER__ADDRESS_MANAGER \
+        TRANSACTION_INDEXER__L2_CHAIN_ID=$TRANSACTION_INDEXER__L2_CHAIN_ID \
         $cmd
 else
     exec $cmd


### PR DESCRIPTION
**Description**
We're renaming the `data-transport-layer` to the `transaction-indexer`. The name "`data-transport-layer`" is too vague so we're changing it while we still can. This is a multi-repo change that involves:

- `data-transport-layer`
- `go-ethereum`
- `docker`
- `optimism-integration`